### PR TITLE
Fix incorrect path for windows

### DIFF
--- a/src/writer/index.js
+++ b/src/writer/index.js
@@ -39,6 +39,8 @@ function getRelativePaths(fromDir, files) {
   return workingFiles.map((file) => {
     let relativePath = path.relative(fromDir, file);
 
+    relativePath  = require('os').platform() === 'win32' ? relativePath.replace(/\\/g, '/') : relativePath;
+
     if (!hasPathPrefix(relativePath)) {
       relativePath = `.${path.sep}${relativePath}`;
     }


### PR DESCRIPTION
Hi,
I'm using react-native-storybook-loader on windows and I'm having this issue:

**When using rnstl, it generates a file with the following content:**

```
  require('..\src\UI\Button\Button.stories.js');
  require('..\src\UI\Title\Title.stories.js');
  require('..\src\components\MainView\MainView.stories.js');
```

As you can see, the library generates a string with backslash. As a consequence, the path is wrong.