### PR TITLE
Replaced 'yarn install' with 'yarn add'

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ getstorybook
 Install react-native-storybook-loader
 
 ```bash
-yarn install react-native-storybook-loader -D
+yarn add react-native-storybook-loader -D
 ```
 
 Update `index.js` file in the `./storybook` directory to point to the generated `storyLoader.js`


### PR DESCRIPTION
When using `yarn install`, yarn raises an error: `error `install` has been replaced with `add` to add new dependencies. Run "yarn add react-native-storybook-loader --dev" instead.`. This change solves that error. 