### PR TITLE
feat: export additionnal list of stories paths

### DIFF
--- a/src/writer/__snapshots__/index.test.js.snap
+++ b/src/writer/__snapshots__/index.test.js.snap
@@ -8,7 +8,6 @@ exports[`writeFile should perform expected work 1`] = `
 // https://github.com/elderfo/react-native-storybook-loader.git
 
 function loadStories() {
-  
   require('./parent/file3.js');
   require('./src/file1.js');
   require('./src/sub/file2.js');
@@ -17,8 +16,18 @@ function loadStories() {
   
 }
 
+const stories = [
+  './parent/file3.js',
+  './src/file1.js',
+  './src/sub/file2.js',
+  './src/writer/sub/file4.js',
+  './src/writer/sub/sub/file5.js',
+  
+];
+
 module.exports = {
   loadStories,
+  stories,
 };
 "
 `;

--- a/src/writer/index.js
+++ b/src/writer/index.js
@@ -21,13 +21,18 @@ const templateContents = `
 // https://github.com/elderfo/react-native-storybook-loader.git
 
 function loadStories() {
-  
   {{~it.files :value:index}}require('{{=value}}');
   {{~}}
 }
 
+const stories = [
+  {{~it.files :value:index}}'{{=value}}',
+  {{~}}
+];
+
 module.exports = {
   loadStories,
+  stories,
 };
 `;
 


### PR DESCRIPTION
Hello,
First of all thanks for the package !

At my current team we have a quite unusual way of using storybook, we don't write stories but mutations which are then rendered to stories.
This look like this:
```js
export default {
    componentName: 'Text',
    mutations: [{
        description: 'Simple Usage',
        mutation: <Text>Hello</Text>,
    }, ... ]
}
```
Our storybook config loop through each mutation and add storybook decorators according to its props.

This PR add an additionnal exported value `stories` to the generated file which is just the raw array of stories paths to be able to apply custom transformation to what's exported in them.