### PR TITLE
feat: strip story files extensions in require calls

### DIFF
--- a/src/writer/__snapshots__/index.test.js.snap
+++ b/src/writer/__snapshots__/index.test.js.snap
@@ -8,20 +8,20 @@ exports[`writeFile should perform expected work 1`] = `
 // https://github.com/elderfo/react-native-storybook-loader.git
 
 function loadStories() {
-  require('./parent/file3.js');
-  require('./src/file1.js');
-  require('./src/sub/file2.js');
-  require('./src/writer/sub/file4.js');
-  require('./src/writer/sub/sub/file5.js');
+  require('./parent/file3');
+  require('./src/file1');
+  require('./src/sub/file2');
+  require('./src/writer/sub/file4');
+  require('./src/writer/sub/sub/file5');
   
 }
 
 const stories = [
-  './parent/file3.js',
-  './src/file1.js',
-  './src/sub/file2.js',
-  './src/writer/sub/file4.js',
-  './src/writer/sub/sub/file5.js',
+  './parent/file3',
+  './src/file1',
+  './src/sub/file2',
+  './src/writer/sub/file4',
+  './src/writer/sub/sub/file5',
   
 ];
 

--- a/src/writer/index.js
+++ b/src/writer/index.js
@@ -38,7 +38,10 @@ module.exports = {
 
 const writeFile = (files, outputFile) => {
   const template = dot.template(templateContents);
-  const relativePaths = getRelativePaths(path.dirname(outputFile), files);
+  const relativePaths = getRelativePaths(
+    path.dirname(outputFile),
+    files
+  ).map(file => file.substring(0, file.lastIndexOf('.'))); // strip file extensions
 
   const output = template({ files: relativePaths });
 


### PR DESCRIPTION
The extensions in the generated loader file are stripped to allow for transpiled files (e.g. tsx) to be used as well.

Closes #51