### PR TITLE
fix: Avoid prettier warning "No parser and no filepath given"

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -65,7 +65,14 @@ const makePrettier = async (template: string): Promise<string> => {
       return prettier.format(template, defaultPrettierOptions);
     }
 
-    return prettier.format(template, prettierConfig);
+    // Since many prettier configs don't include the `parser` option (the
+    // Prettier docs recommend against setting it and letting Prettier infer
+    // based on the file-name), we include `...defaultPrettierOptions` here
+    // before `...prettierConfig`.
+    return prettier.format(template, {
+      ...defaultPrettierOptions,
+      ...prettierConfig,
+    });
   } catch (err) {
     logger.warn(
       `Something went awry while trying to get the prettier config, falling back to default formatting [${err}]`


### PR DESCRIPTION
## Problem

Many `.prettierrc` files exclude the `parser` argument, because [Prettier's docs recommend against including it at the top-level](https://prettier.io/docs/en/configuration.html#setting-the-parserdocsenoptionshtmlparser-option:~:text=Never%20put%20the%20parser%20option%20at%20the%20top%20level%20of%20your%20configuration).

> Note: Never put the parser option at the top level of your configuration. Only use it inside overrides. Otherwise you effectively disable Prettier’s automatic file extension based parser inference. This forces Prettier to use the parser you specified for all types of files – even when it doesn’t make sense, such as trying to parse a CSS file as JavaScript.

When you run `rnstl `in those projects though, it gives the error:

```
Attempting to use prettier configuration detected at /Users/harry/code/itineraries/.prettierrc.yaml
No parser and no filepath given, using 'babel' the parser now but this will throw an error in the future. Please specify a parser or a filepath so one can be inferred.
Writing to /Users/harry/code/itineraries/mobile/storybook/storyLoader.js
```

## Fix

Set the parser option to babel by default, even when there is a prettierrc file.

## Testing

2. Installed project locally in a directory using `rnstl`
3. Ran `yarn rnstl`
4. Verified no error shows up

```
$ /Users/harry/code/itineraries/mobile/node_modules/.bin/rnstl
Attempting to use prettier configuration detected at /Users/harry/code/itineraries/.prettierrc.yaml
Writing to /Users/harry/code/itineraries/mobile/storybook/storyLoader.js
```