### PR TITLE
feat: export a list of modules for use in @storybook/react-native 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ An array of the stories that are loaded.
 
 Returns: `string[]`
 
+### storyLoader.modules
+
+An array of the modules to load.
+
+Returns: `NodeRequire[]`
+
 ## Story Loader Formatting
 
 To ensure the formatting of your story loader is on par with the rest of your code base, `rnstl` uses [Prettier](https://prettier.io/) to format the generated story loaders. It will travese up the tree looking for a [Prettier configuration file](https://prettier.io/docs/en/configuration.html). If none is found, the defaul Prettier settings will be used.

--- a/src/__snapshots__/template.test.ts.snap
+++ b/src/__snapshots__/template.test.ts.snap
@@ -23,11 +23,11 @@ const stories = [
 ];
 
 const modules = [
-  require('../file1.tsx'),
-  require('../sub/file2.tsx'),
-  require('../../parent/file3.tsx'),
-  require('./sub/file4.tsx'),
-  require('./sub/sub/file5.tsx'),
+  require('../file1'),
+  require('../sub/file2'),
+  require('../../parent/file3'),
+  require('./sub/file4'),
+  require('./sub/sub/file5'),
 ];
 
 module.exports = {

--- a/src/__snapshots__/template.test.ts.snap
+++ b/src/__snapshots__/template.test.ts.snap
@@ -33,7 +33,7 @@ const modules = [
 module.exports = {
   loadStories,
   stories,
-  modules
+  modules,
 };
 "
 `;

--- a/src/__snapshots__/template.test.ts.snap
+++ b/src/__snapshots__/template.test.ts.snap
@@ -23,11 +23,11 @@ const stories = [
 ];
 
 const modules = [
-  '../file1.tsx',
-  '../sub/file2.tsx',
-  '../../parent/file3.tsx',
-  './sub/file4.tsx',
-  './sub/sub/file5.tsx',
+  require('../file1.tsx'),
+  require('../sub/file2.tsx'),
+  require('../../parent/file3.tsx'),
+  require('./sub/file4.tsx'),
+  require('./sub/sub/file5.tsx'),
 ];
 
 module.exports = {

--- a/src/__snapshots__/template.test.ts.snap
+++ b/src/__snapshots__/template.test.ts.snap
@@ -22,9 +22,18 @@ const stories = [
   './sub/sub/file5',
 ];
 
+const modules = [
+  '../file1.tsx',
+  '../sub/file2.tsx',
+  '../../parent/file3.tsx',
+  './sub/file4.tsx',
+  './sub/sub/file5.tsx',
+];
+
 module.exports = {
   loadStories,
   stories,
+  modules
 };
 "
 `;

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -7,6 +7,7 @@ import { Configuration } from './configuration';
 export type LoaderDefinition = {
   outputFile: string;
   storyFiles: string[];
+  modules: string[];
 };
 
 export const generateLoaderDefinition = async ({
@@ -35,6 +36,9 @@ export const generateLoaderDefinition = async ({
     storyFiles: uniqueFiles
       .map(f => getRelativePath(f, outputFileDir))
       .map(f => stripExtension(f))
+      .map(f => formatPath(f)),
+    modules: uniqueFiles
+      .map(f => getRelativePath(f, outputFileDir))
       .map(f => formatPath(f)),
   };
 };

--- a/src/template.test.ts
+++ b/src/template.test.ts
@@ -8,11 +8,11 @@ describe('generateTemplate', () => {
     const def: LoaderDefinition = {
       outputFile: faker.system.fileName(),
       storyFiles: [
-        '../file1.tsx',
-        '../sub/file2.tsx',
-        '../../parent/file3.tsx',
-        './sub/file4.tsx',
-        './sub/sub/file5.tsx',
+        '../file1',
+        '../sub/file2',
+        '../../parent/file3',
+        './sub/file4',
+        './sub/sub/file5',
       ],
     };
 

--- a/src/template.test.ts
+++ b/src/template.test.ts
@@ -8,11 +8,11 @@ describe('generateTemplate', () => {
     const def: LoaderDefinition = {
       outputFile: faker.system.fileName(),
       storyFiles: [
-        '../file1',
-        '../sub/file2',
-        '../../parent/file3',
-        './sub/file4',
-        './sub/sub/file5',
+        '../file1.tsx',
+        '../sub/file2.tsx',
+        '../../parent/file3.tsx',
+        './sub/file4.tsx',
+        './sub/sub/file5.tsx',
       ],
     };
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -33,7 +33,7 @@ export const generateTemplate = async (
   ];
   
   const modules = [
-  ${formatter(loader.modules, file => `require('${file}')`, ',\n')}
+  ${formatter(loader.storyFiles, file => `require('${file}')`, ',\n')}
   ];
   
   module.exports = {

--- a/src/template.ts
+++ b/src/template.ts
@@ -33,7 +33,7 @@ export const generateTemplate = async (
   ];
   
   const modules = [
-  ${formatter(loader.storyFiles, file => `require('${file}');`, '\n')}
+  ${formatter(loader.storyFiles, file => `require('${file}')`, ',\n')}
   ];
   
   module.exports = {

--- a/src/template.ts
+++ b/src/template.ts
@@ -33,7 +33,7 @@ export const generateTemplate = async (
   ];
   
   const modules = [
-  ${formatter(loader.storyFiles, file => `require('${file}')`, ',\n')}
+  ${formatter(loader.modules, file => `require('${file}')`, ',\n')}
   ];
   
   module.exports = {

--- a/src/template.ts
+++ b/src/template.ts
@@ -32,9 +32,14 @@ export const generateTemplate = async (
   ${formatter(loader.storyFiles, file => `'${file}'`, ',\n')}
   ];
   
+  const modules = [
+  ${formatter(loader.storyFiles, file => `require('${file}');`, '\n')}
+  ];
+  
   module.exports = {
     loadStories,
     stories,
+    modules,
   };
   `;
 


### PR DESCRIPTION
`loadStories()` and `stories` are of no use in storybook for react-native v6, so I've just added this additional export that can be used instead of loadStories in configure, eg:
```
import { modules } from './storyLoader';
...
configure(( ) => {
   return modules
}, module)
```